### PR TITLE
Fixed typo in headline

### DIFF
--- a/docs/requirement-4.9.rst
+++ b/docs/requirement-4.9.rst
@@ -1,4 +1,4 @@
-4.9 Access control rules are enfoced server side
+4.9 Access control rules are enforced server side
 ================================================
 
 Verify that the same access control rules implied by the presentation layer are enforced on the server side.


### PR DESCRIPTION
The headline read "enfoced", changed it to "enforced"